### PR TITLE
Min height for level containers

### DIFF
--- a/public/app/style.css
+++ b/public/app/style.css
@@ -33,3 +33,13 @@ img { display:none; }
 .label-style {
     color:rgb(38, 166, 154)
 }
+
+.level1 {
+    min-height: 560px;
+}
+
+.level2,
+.level3,
+.level4 {
+    min-height: 650px;
+}


### PR DESCRIPTION
I've just realized that this fix brach should me made from develop and merged in develop as well. Anyway...

It's a styling issue.
The problem was that svgs have 'overflow: hidden' by default, so when the container resized the part of the svgs that leaves outside remains hidden. You can spot that clearly on lvl 2. Other levels have some absolute positioned buttons, therefore rezising the body height leaves us with a scroll to fit them on screen. The level div resizes according to the screen height and this is when its starting to get really ugly :)

I could have changed svg 'overflow' option to 'visible' but I prefer giving the level a little more space. 
So I've added min-height to all level containers.
